### PR TITLE
feat: add support and error translations

### DIFF
--- a/PROGRESSION_TRADUCTION.md
+++ b/PROGRESSION_TRADUCTION.md
@@ -1,0 +1,29 @@
+# Progression Traduction
+
+## Phase 1
+- [x] Support.tsx (25)
+- [x] NotFound.tsx (12)
+- [x] ErrorBoundary.tsx (5)
+- [x] Messages globaux (15)
+
+## Phase 2
+- [ ] BlockchainFundamentals.tsx (50)
+- [ ] BitcoinHistory.tsx (45)
+- [ ] CryptoEducation.tsx (60)
+- [ ] CryptographySecurity.tsx (55)
+- [ ] DecentralizationPrinciples.tsx (40)
+- [ ] EthereumSmartContracts.tsx (45)
+- [ ] WalletSecurity.tsx + WalletsSecurity.tsx (90)
+- [ ] BlockchainTypes.tsx (40)
+- [ ] TokenTypes.tsx (45)
+- [ ] TechnicalAnalysis.tsx (50)
+
+## Phase 3
+- [ ] quizQuestions.ts (~200 questions et réponses)
+- [ ] TermsOfService.tsx (100)
+- [ ] PrivacyPolicy.tsx (80)
+- [ ] Team.tsx (30)
+- [ ] Values.tsx (25)
+
+Total : 850+ traductions
+Complété : 57/850 (6.7 %)

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,7 +1,8 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { withTranslation, WithTranslation } from 'react-i18next';
 
-interface Props {
+interface Props extends WithTranslation {
   children: ReactNode;
 }
 
@@ -36,22 +37,22 @@ class ErrorBoundary extends Component<Props, State> {
               <AlertTriangle className="h-8 w-8 text-red-600" />
             </div>
             <h1 className="text-2xl font-bold text-gray-900 mb-4">
-              Erreur de chargement
+              {this.props.t('errorBoundary.header.title')}
             </h1>
             <p className="text-gray-600 mb-6">
-              Une erreur s'est produite lors du chargement de l'application.
+              {this.props.t('errorBoundary.header.subtitle')}
             </p>
             <button
               onClick={this.handleReload}
               className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
             >
               <RefreshCw className="h-4 w-4 mr-2" />
-              Recharger la page
+              {this.props.t('errorBoundary.buttons.reload')}
             </button>
             {process.env.NODE_ENV === 'development' && (
               <details className="mt-4 text-left">
                 <summary className="cursor-pointer text-sm text-gray-500">
-                  Détails de l'erreur (dev uniquement)
+                  {this.props.t('errorBoundary.content.devDetails')}
                 </summary>
                 <pre className="mt-2 text-xs bg-gray-100 p-2 rounded overflow-auto">
                   {this.state.error?.stack}
@@ -67,4 +68,4 @@ class ErrorBoundary extends Component<Props, State> {
   }
 }
 
-export default ErrorBoundary;
+export default withTranslation()(ErrorBoundary);

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Home, Search, BookOpen } from 'lucide-react';
 import SEOHead from './SEOHead';
+import { useTranslation } from 'react-i18next';
 
 export default function NotFound() {
+  const { t } = useTranslation();
   return (
     <>
-      <SEOHead 
-        title="Page non trouvée - Alyah Knowledge"
-        description="La page que vous recherchez n'existe pas. Explorez nos ressources crypto et formations."
+      <SEOHead
+        title={t('notFoundPage.seo.title')}
+        description={t('notFoundPage.seo.description')}
         noindex={true}
         path="/404"
       />
@@ -19,10 +21,10 @@ export default function NotFound() {
               <span className="text-4xl font-bold text-blue-600">404</span>
             </div>
             <h1 className="text-4xl font-bold text-gray-900 mb-4">
-              Page non trouvée
+              {t('notFoundPage.header.title')}
             </h1>
             <p className="text-xl text-gray-600 mb-8">
-              La page que vous recherchez n'existe pas ou a été déplacée.
+              {t('notFoundPage.header.subtitle')}
             </p>
           </div>
           
@@ -32,52 +34,52 @@ export default function NotFound() {
               className="inline-flex items-center justify-center px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors duration-200"
             >
               <Home className="mr-2 h-5 w-5" />
-              Accueil
+              {t('notFoundPage.buttons.home')}
             </Link>
             <Link
               to="/dictionnaire-crypto"
               className="inline-flex items-center justify-center px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors duration-200"
             >
               <Search className="mr-2 h-5 w-5" />
-              Dictionnaire
+              {t('notFoundPage.buttons.dictionary')}
             </Link>
             <Link
               to="/articles"
               className="inline-flex items-center justify-center px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors duration-200"
             >
               <BookOpen className="mr-2 h-5 w-5" />
-              Articles
+              {t('notFoundPage.buttons.articles')}
             </Link>
           </div>
 
           <div className="bg-gray-50 rounded-xl p-6">
             <h2 className="text-lg font-semibold text-gray-900 mb-3">
-              Ressources populaires
+              {t('notFoundPage.content.popularResources')}
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
-              <Link 
-                to="/comprendre-les-cryptomonnaies" 
+              <Link
+                to="/comprendre-les-cryptomonnaies"
                 className="text-blue-600 hover:text-blue-800 transition-colors"
               >
-                → Formation crypto complète
+                {t('notFoundPage.content.link1')}
               </Link>
-              <Link 
-                to="/marche-cryptomonnaies-temps-reel" 
+              <Link
+                to="/marche-cryptomonnaies-temps-reel"
                 className="text-blue-600 hover:text-blue-800 transition-colors"
               >
-                → Marché en temps réel
+                {t('notFoundPage.content.link2')}
               </Link>
-              <Link 
-                to="/dictionnaire-crypto/bitcoin" 
+              <Link
+                to="/dictionnaire-crypto/bitcoin"
                 className="text-blue-600 hover:text-blue-800 transition-colors"
               >
-                → Qu'est-ce que Bitcoin ?
+                {t('notFoundPage.content.link3')}
               </Link>
-              <Link 
-                to="/signaux-trading" 
+              <Link
+                to="/signaux-trading"
                 className="text-blue-600 hover:text-blue-800 transition-colors"
               >
-                → Signaux de trading
+                {t('notFoundPage.content.link4')}
               </Link>
             </div>
           </div>

--- a/src/data/quizQuestions.ts
+++ b/src/data/quizQuestions.ts
@@ -743,7 +743,6 @@ export const module20Questions = [
 ];
 
 // Utility function to get questions by module
- pour récupérer les questions d'un module
 export const getQuestionsByModule = (moduleId: string) => {
   const moduleMap: Record<string, any[]> = {
     'module-1': module1Questions,

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -265,18 +265,89 @@ const resources = {
         dictionary: 'Dictionnaire',
         copyright: 'Copyright © {year} Alyah Knowledge Investissement. Tous droits réservés.'
       },
-      // Messages d'erreur globaux
+      supportPage: {
+        seo: {
+          title: 'Assistance',
+          description: "Contactez l'équipe d'Alyah Knowledge pour toute question ou assistance. Nous sommes là pour vous aider."
+        },
+        header: {
+          title: 'Assistance',
+          subtitle: "Notre équipe est là pour vous aider. Remplissez le formulaire ci-dessous et nous vous répondrons dans les plus brefs délais."
+        },
+        form: {
+          labels: {
+            name: 'Nom complet',
+            email: 'Email',
+            subject: 'Sujet',
+            message: 'Message'
+          },
+          placeholders: {
+            name: 'Votre nom',
+            email: 'votre@email.com',
+            subject: 'Le sujet de votre message',
+            message: 'Décrivez votre demande en détail...'
+          },
+          emailSubjectPrefix: "Nouvelle demande d'assistance Alyah"
+        },
+        buttons: {
+          submit: 'Envoyer le message',
+          sending: 'Envoi en cours...'
+        },
+        messages: {
+          success: 'Votre message a été envoyé avec succès. Nous vous répondrons dans les plus brefs délais.',
+          error: "Une erreur est survenue lors de l'envoi du message. Veuillez réessayer plus tard."
+        }
+      },
+      notFoundPage: {
+        seo: {
+          title: 'Page non trouvée - Alyah Knowledge',
+          description: "La page que vous recherchez n'existe pas. Explorez nos ressources crypto et formations."
+        },
+        header: {
+          title: 'Page non trouvée',
+          subtitle: "La page que vous recherchez n'existe pas ou a été déplacée."
+        },
+        buttons: {
+          home: 'Accueil',
+          dictionary: 'Dictionnaire',
+          articles: 'Articles'
+        },
+        content: {
+          popularResources: 'Ressources populaires',
+          link1: '→ Formation crypto complète',
+          link2: '→ Marché en temps réel',
+          link3: "→ Qu'est-ce que Bitcoin ?",
+          link4: '→ Signaux de trading'
+        }
+      },
+      errorBoundary: {
+        header: {
+          title: 'Erreur de chargement',
+          subtitle: "Une erreur s'est produite lors du chargement de l'application."
+        },
+        buttons: {
+          reload: 'Recharger la page'
+        },
+        content: {
+          devDetails: "Détails de l'erreur (dev uniquement)"
+        }
+      },
       errors: {
-        generic: 'Une erreur s\'est produite',
-        networkError: 'Erreur de connexion réseau',
-        serverError: 'Erreur du serveur',
-        unauthorized: 'Accès non autorisé',
-        forbidden: 'Accès interdit',
-        notFound: 'Page non trouvée',
-        validation: 'Erreur de validation',
-        tryAgain: 'Veuillez réessayer',
-        goHome: 'Retour à l\'accueil',
-        contactSupport: 'Contacter le support'
+        network: 'Erreur réseau. Veuillez vérifier votre connexion.',
+        unknown: 'Une erreur inconnue est survenue.',
+        unauthorized: 'Vous devez être connecté pour accéder à cette page.',
+        forbidden: "Vous n'avez pas la permission d'accéder à cette ressource.",
+        notFound: 'La ressource demandée est introuvable.',
+        serverError: 'Erreur interne du serveur. Veuillez réessayer plus tard.',
+        timeout: 'La demande a expiré. Veuillez réessayer.',
+        invalidInput: 'Entrée invalide.',
+        emailInUse: 'Cette adresse e-mail est déjà utilisée.',
+        weakPassword: 'Mot de passe trop faible.',
+        tooManyRequests: 'Trop de tentatives. Veuillez réessayer plus tard.',
+        maintenance: 'Le service est actuellement en maintenance.',
+        paymentFailed: 'Le paiement a échoué.',
+        formIncomplete: 'Veuillez remplir tous les champs requis.',
+        subscriptionRequired: 'Un abonnement actif est requis.'
       },
       quizQuestions: {
     question1: {
@@ -1205,18 +1276,89 @@ const resources = {
         dictionary: 'Dictionary',
         copyright: 'Copyright © {year} Alyah Knowledge Investment. All rights reserved.'
       },
-      // Global error messages
+      supportPage: {
+        seo: {
+          title: 'Support',
+          description: "Contact the Alyah Knowledge team for any questions or assistance. We're here to help."
+        },
+        header: {
+          title: 'Support',
+          subtitle: "Our team is here to help. Fill out the form below and we'll respond as soon as possible."
+        },
+        form: {
+          labels: {
+            name: 'Full name',
+            email: 'Email',
+            subject: 'Subject',
+            message: 'Message'
+          },
+          placeholders: {
+            name: 'Your name',
+            email: 'your@email.com',
+            subject: 'The subject of your message',
+            message: 'Describe your request in detail...'
+          },
+          emailSubjectPrefix: 'New Alyah support request'
+        },
+        buttons: {
+          submit: 'Send message',
+          sending: 'Sending...'
+        },
+        messages: {
+          success: 'Your message has been sent successfully. We will respond as soon as possible.',
+          error: 'An error occurred while sending the message. Please try again later.'
+        }
+      },
+      notFoundPage: {
+        seo: {
+          title: 'Page not found - Alyah Knowledge',
+          description: 'The page you are looking for does not exist. Explore our crypto resources and training.'
+        },
+        header: {
+          title: 'Page not found',
+          subtitle: 'The page you are looking for does not exist or has been moved.'
+        },
+        buttons: {
+          home: 'Home',
+          dictionary: 'Dictionary',
+          articles: 'Articles'
+        },
+        content: {
+          popularResources: 'Popular resources',
+          link1: '→ Complete crypto training',
+          link2: '→ Real-time market',
+          link3: '→ What is Bitcoin?',
+          link4: '→ Trading signals'
+        }
+      },
+      errorBoundary: {
+        header: {
+          title: 'Loading error',
+          subtitle: 'An error occurred while loading the application.'
+        },
+        buttons: {
+          reload: 'Reload page'
+        },
+        content: {
+          devDetails: 'Error details (dev only)'
+        }
+      },
       errors: {
-        generic: 'An error occurred',
-        networkError: 'Network connection error',
-        serverError: 'Server error',
-        unauthorized: 'Unauthorized access',
-        forbidden: 'Access forbidden',
-        notFound: 'Page not found',
-        validation: 'Validation error',
-        tryAgain: 'Please try again',
-        goHome: 'Go home',
-        contactSupport: 'Contact support'
+        network: 'Network error. Please check your connection.',
+        unknown: 'An unknown error occurred.',
+        unauthorized: 'You must be logged in to access this page.',
+        forbidden: 'You do not have permission to access this resource.',
+        notFound: 'The requested resource was not found.',
+        serverError: 'Internal server error. Please try again later.',
+        timeout: 'The request timed out. Please try again.',
+        invalidInput: 'Invalid input.',
+        emailInUse: 'This email address is already in use.',
+        weakPassword: 'Password is too weak.',
+        tooManyRequests: 'Too many attempts. Please try again later.',
+        maintenance: 'The service is currently under maintenance.',
+        paymentFailed: 'Payment failed.',
+        formIncomplete: 'Please complete all required fields.',
+        subscriptionRequired: 'An active subscription is required.'
       },
       quizQuestions: {
     question1: {

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { Mail, MessageSquare, Send } from 'lucide-react';
 import SEOHead from '../components/SEOHead';
+import { useTranslation } from 'react-i18next';
 
 export default function Support() {
+  const { t } = useTranslation();
   const [formData, setFormData] = useState({
     name: '',
     email: '',
@@ -17,7 +19,7 @@ export default function Support() {
     setIsSubmitting(true);
     
     try {
-      // Ici, nous utilisons un service de formulaire gratuit pour envoyer l'email
+      // Here we use a free form service to send the email
       const response = await fetch('https://formsubmit.co/ajax/jordan.cinvest@gmail.com', {
         method: 'POST',
         headers: {
@@ -26,7 +28,7 @@ export default function Support() {
         },
         body: JSON.stringify({
           ...formData,
-          _subject: `Nouvelle demande d'assistance Alyah: ${formData.subject}`,
+          _subject: `${t('supportPage.form.emailSubjectPrefix')}: ${formData.subject}`,
         }),
       });
 
@@ -54,17 +56,18 @@ export default function Support() {
   return (
     <>
     <SEOHead
-      title="Assistance"
-      description="Contactez l'équipe d'Alyah Knowledge pour toute question ou assistance. Nous sommes là pour vous aider."
+      title={t('supportPage.seo.title')}
+      description={t('supportPage.seo.description')}
       canonicalUrl="https://alyah-knowledge.com/support"
     />
     <div className="min-h-screen pt-28 px-4 sm:px-6 lg:px-8">
       <div className="max-w-4xl mx-auto">
         <div className="text-center mb-16">
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">Assistance</h1>
+          <h1 className="text-4xl font-bold text-gray-900 mb-4">
+            {t('supportPage.header.title')}
+          </h1>
           <p className="text-xl text-gray-600">
-            Notre équipe est là pour vous aider. Remplissez le formulaire ci-dessous
-            et nous vous répondrons dans les plus brefs délais.
+            {t('supportPage.header.subtitle')}
           </p>
         </div>
 
@@ -73,7 +76,7 @@ export default function Support() {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div>
                 <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
-                  Nom complet
+                  {t('supportPage.form.labels.name')}
                 </label>
                 <div className="relative">
                   <input
@@ -83,17 +86,17 @@ export default function Support() {
                     required
                     value={formData.name}
                     onChange={handleChange}
-                    className="w-full px-4 py-3 rounded-xl border border-gray-300 focus:ring-2 
+                    className="w-full px-4 py-3 rounded-xl border border-gray-300 focus:ring-2
                       focus:ring-blue-500 focus:border-transparent transition-all duration-200
                       placeholder-gray-400"
-                    placeholder="Votre nom"
+                    placeholder={t('supportPage.form.placeholders.name')}
                   />
                 </div>
               </div>
 
               <div>
                 <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
-                  Email
+                  {t('supportPage.form.labels.email')}
                 </label>
                 <div className="relative">
                   <input
@@ -103,10 +106,10 @@ export default function Support() {
                     required
                     value={formData.email}
                     onChange={handleChange}
-                    className="w-full px-4 py-3 rounded-xl border border-gray-300 focus:ring-2 
+                    className="w-full px-4 py-3 rounded-xl border border-gray-300 focus:ring-2
                       focus:ring-blue-500 focus:border-transparent transition-all duration-200
                       placeholder-gray-400"
-                    placeholder="votre@email.com"
+                    placeholder={t('supportPage.form.placeholders.email')}
                   />
                   <Mail className="absolute right-3 top-3 h-5 w-5 text-gray-400" />
                 </div>
@@ -115,7 +118,7 @@ export default function Support() {
 
             <div>
               <label htmlFor="subject" className="block text-sm font-medium text-gray-700 mb-2">
-                Sujet
+                {t('supportPage.form.labels.subject')}
               </label>
               <input
                 type="text"
@@ -124,16 +127,16 @@ export default function Support() {
                 required
                 value={formData.subject}
                 onChange={handleChange}
-                className="w-full px-4 py-3 rounded-xl border border-gray-300 focus:ring-2 
+                className="w-full px-4 py-3 rounded-xl border border-gray-300 focus:ring-2
                   focus:ring-blue-500 focus:border-transparent transition-all duration-200
                   placeholder-gray-400"
-                placeholder="Le sujet de votre message"
+                placeholder={t('supportPage.form.placeholders.subject')}
               />
             </div>
 
             <div>
               <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-2">
-                Message
+                {t('supportPage.form.labels.message')}
               </label>
               <div className="relative">
                 <textarea
@@ -143,10 +146,10 @@ export default function Support() {
                   value={formData.message}
                   onChange={handleChange}
                   rows={6}
-                  className="w-full px-4 py-3 rounded-xl border border-gray-300 focus:ring-2 
+                  className="w-full px-4 py-3 rounded-xl border border-gray-300 focus:ring-2
                     focus:ring-blue-500 focus:border-transparent transition-all duration-200
                     placeholder-gray-400 resize-none"
-                  placeholder="Décrivez votre demande en détail..."
+                  placeholder={t('supportPage.form.placeholders.message')}
                 />
                 <MessageSquare className="absolute right-3 top-3 h-5 w-5 text-gray-400" />
               </div>
@@ -166,12 +169,12 @@ export default function Support() {
                 {isSubmitting ? (
                   <>
                     <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-3" />
-                    Envoi en cours...
+                    {t('supportPage.buttons.sending')}
                   </>
                 ) : (
                   <>
                     <Send className="h-5 w-5 mr-2" />
-                    Envoyer le message
+                    {t('supportPage.buttons.submit')}
                   </>
                 )}
               </button>
@@ -186,7 +189,7 @@ export default function Support() {
                 </div>
                 <div className="ml-3">
                   <p className="text-sm font-medium">
-                    Votre message a été envoyé avec succès. Nous vous répondrons dans les plus brefs délais.
+                    {t('supportPage.messages.success')}
                   </p>
                 </div>
               </div>
@@ -201,7 +204,7 @@ export default function Support() {
                 </div>
                 <div className="ml-3">
                   <p className="text-sm font-medium">
-                    Une erreur est survenue lors de l'envoi du message. Veuillez réessayer plus tard.
+                    {t('supportPage.messages.error')}
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- internationalize Support page with i18n keys
- translate 404 and error boundary components
- add global error messages and progress tracking

## Testing
- `npm run build`
- `npm run dev` (start and kill)


------
https://chatgpt.com/codex/tasks/task_e_689fb11bfbb0832385d2bd9c7ebe0c3c